### PR TITLE
Fix turn-signal, hazard, and momentary-relay behavior

### DIFF
--- a/lights_v2/lights_relay/src/main.cpp
+++ b/lights_v2/lights_relay/src/main.cpp
@@ -25,7 +25,23 @@ Bitset inputState {};
 uint8_t prevData[PINS] = {};
 
 unsigned long flasherT0 = 0;
+unsigned long hazardT0 = 0;
+bool hazardPhase = false;
+bool prevLeftSignal = false;
+bool prevRightSignal = false;
+bool prevHazard = false;
+bool prevHeadlights = false;
+bool prevBrake = false;
+bool prevHorn = false;
 const unsigned long interval = 500;
+
+// Announce a signal on its rising edge only. Printing every loop while a button
+// is held stalls the loop long enough to back up the CAN RX buffers, which makes
+// presses register late.
+inline void logOnRise(bool state, bool &prev, const char *label) {
+  if (state && !prev) Serial.println(label);
+  prev = state;
+}
 
 
 MCP2515 mcp2515(10);
@@ -39,9 +55,10 @@ struct Relay {
 
   Relay(uint8_t pin) : pin(pin) {}
 
-  inline void init()      { pinMode(pin, OUTPUT); digitalWrite(pin, HIGH); }
-  inline void close()     { digitalWrite(pin, LOW);  closed = true; }
-  inline void open()      { digitalWrite(pin, HIGH); closed = false; }
+  // Active-high relay module: driving the pin HIGH energizes (closes) the relay.
+  inline void init()      { pinMode(pin, OUTPUT); digitalWrite(pin, LOW); }
+  inline void close()     { digitalWrite(pin, HIGH); closed = true; }
+  inline void open()      { digitalWrite(pin, LOW);  closed = false; }
   inline void toggle()    { closed ? open() : close(); }
   inline bool isClosed()  { return closed; }
 
@@ -55,13 +72,15 @@ struct Relay {
  *
 */ 
 
-Relay headlights(2);
-Relay leftFrontBlinker(3);
-Relay rightFrontBlinker(4);
-Relay backRightBlinker(5);
-Relay backLeftBlinker(6);
-Relay topBrakeLight(7);
-Relay horn(8);
+Relay horn(A0);              // horn
+Relay headlights(A1);        // headlights
+Relay backLeftBlinker(A2);   // left rear indicator
+Relay backRightBlinker(A3);  // right rear indicator
+Relay topBrakeLight(A4);     // brake light
+// A6/A7 are analog-input-only on the Nano's ATmega328P (no GPIO output driver),
+// so the front blinkers can't live there - moved to digital pins D2/D3.
+Relay leftFrontBlinker(2);   // left turn signal
+Relay rightFrontBlinker(3);  // right turn signal
 
 Button RightSignal(0, true);
 Button HeadlightsBtn(1, true);
@@ -139,25 +158,66 @@ void loop() {
   bool hazardBtn     = HazardBtn.update(inputState.test(6));
   bool leftSignal    = LeftSignal.update(inputState.test(7));
 
-  // Hazards
+  // Turn signals are mutually exclusive, like a physical turn stalk: engaging
+  // one side cancels the other so both can never latch on at once. Both-on is a
+  // state the driver has no way to clear (only hazards flash both sides), and it
+  // also left the two flashers fighting over the shared timer - the starved side
+  // stayed latched but invisible, so pressing one side appeared to toggle the
+  // other and the signals could never be turned off.
+  bool leftEngaged  = leftSignal  && !prevLeftSignal;
+  bool rightEngaged = rightSignal && !prevRightSignal;
+  if (leftEngaged) {
+    RightSignal.on = false;
+    rightSignal = false;
+    rightEngaged = false;
+  }
+  if (rightEngaged) {
+    LeftSignal.on = false;
+    leftSignal = false;
+  }
+  prevLeftSignal  = leftSignal;
+  prevRightSignal = rightSignal;
+
+  // Announce each signal on its rising edge only (see logOnRise). The turn
+  // signals already carry engage edges from the mutual-exclusion pass above.
+  if (leftEngaged)  Serial.println("left signal");
+  if (rightEngaged) Serial.println("right signal");
+  logOnRise(hazardBtn, prevHazard, "hazards");
+  logOnRise(headlightsBtn, prevHeadlights, "headlights");
+  logOnRise(brakeSignal, prevBrake, "brake");
+  logOnRise(hornBtn, prevHorn, "horn");
+
+  // Hazards: flash all four indicators together. Drive every lamp to a single
+  // shared phase off a dedicated timer (rather than toggle()ing each one), so a
+  // brake tap or a latched turn signal can't leave one lamp inverted and put
+  // the hazards out of sync. Takes priority over the turn signals below.
   if (hazardBtn) {
-    Serial.println("hazards");
-    if (millis() - flasherT0 >= interval) {
-      leftFrontBlinker.toggle();
-      rightFrontBlinker.toggle();
-      backLeftBlinker.toggle();
-      backRightBlinker.toggle();
-      flasherT0 = millis();
+    if (millis() - hazardT0 >= interval) {
+      hazardPhase = !hazardPhase;
+      hazardT0 = millis();
+    }
+    if (hazardPhase) {
+      leftFrontBlinker.close();
+      rightFrontBlinker.close();
+      backLeftBlinker.close();
+      backRightBlinker.close();
+    } else {
+      leftFrontBlinker.open();
+      rightFrontBlinker.open();
+      backLeftBlinker.open();
+      backRightBlinker.open();
     }
   } else {
+    hazardPhase = false;
     if (leftFrontBlinker.isClosed())  leftFrontBlinker.open();
     if (rightFrontBlinker.isClosed()) rightFrontBlinker.open();
   }
 
-  // Left turn signal
-  if (leftSignal) {
-    Serial.println("left signal");
-    if (millis() - flasherT0 >= interval) {
+  // Left turn signal (suppressed while hazards own the lamps). A freshly engaged
+  // signal fires immediately so it lights on press instead of waiting out a
+  // stale timer left over from the other side.
+  if (leftSignal && !hazardBtn) {
+    if (leftEngaged || millis() - flasherT0 >= interval) {
       leftFrontBlinker.toggle();
       backLeftBlinker.toggle();
       flasherT0 = millis();
@@ -166,10 +226,9 @@ void loop() {
     if (leftFrontBlinker.isClosed()) leftFrontBlinker.open();
   }
 
-  // Right turn signal
-  if (rightSignal) {
-    Serial.println("right signal");
-    if (millis() - flasherT0 >= interval) {
+  // Right turn signal (suppressed while hazards own the lamps)
+  if (rightSignal && !hazardBtn) {
+    if (rightEngaged || millis() - flasherT0 >= interval) {
       rightFrontBlinker.toggle();
       backRightBlinker.toggle();
       flasherT0 = millis();
@@ -180,7 +239,6 @@ void loop() {
 
   // Headlights
   if (headlightsBtn) {
-    Serial.println("headlights");
     headlights.close();
   } else {
     if (headlights.isClosed()) headlights.open();
@@ -188,7 +246,6 @@ void loop() {
 
   // Brake
   if (brakeSignal) {
-    Serial.println("brake");
     topBrakeLight.close();
     if (!leftSignal || !hazardBtn) {
       backLeftBlinker.close();
@@ -208,7 +265,6 @@ void loop() {
 
   // Horn
   if (hornBtn) {
-    Serial.println("horn");
     horn.close();
   } else {
     if (horn.isClosed()) horn.open();

--- a/lights_v2/lights_relay/test/test_button/test_button.cpp
+++ b/lights_v2/lights_relay/test/test_button/test_button.cpp
@@ -36,8 +36,59 @@ void test_toggle_button_alternates_every_press(void) {
         "3rd press: relay should turn back ON");
 }
 
+// A momentary button (horn, brake) must stay closed for the *entire* time its
+// pin is held, i.e. across every CAN frame the steering wheel sends while the
+// button is down - not just the rising-edge frame. Regression guard for the
+// steering wheel transmitting held state (level) instead of only the edge.
+void test_momentary_button_held_across_frames(void) {
+    Bitset state{0};
+    uint8_t prevData[8] = {0};
+    Button horn(3, false);
+
+    // Steering wheel sends the pin number on every frame while it is held.
+    uint8_t down[8] = {0};
+    down[3] = 0x05;
+    for (uint8_t frame = 0; frame < 5; frame++) {
+        updateInputState(state, prevData, down, 8);
+        TEST_ASSERT_TRUE_MESSAGE(horn.update(state.test(3)),
+            "held frame: momentary relay should stay CLOSED");
+    }
+
+    // Releasing the button (zeroed frames) must open the relay.
+    uint8_t up[8] = {0};
+    updateInputState(state, prevData, up, 8);
+    TEST_ASSERT_FALSE_MESSAGE(horn.update(state.test(3)),
+        "release: momentary relay should OPEN");
+}
+
+// A toggle button must still register exactly one flip when the press spans
+// many held frames (level-triggered), and must not double-toggle mid-hold.
+void test_toggle_button_flips_once_per_held_press(void) {
+    Bitset state{0};
+    uint8_t prevData[8] = {0};
+    Button leftSignal(7, true);
+
+    uint8_t down[8] = {0};
+    down[7] = 0x09;
+    bool on = false;
+    for (uint8_t frame = 0; frame < 5; frame++) {
+        updateInputState(state, prevData, down, 8);
+        on = leftSignal.update(state.test(7));
+    }
+    TEST_ASSERT_TRUE_MESSAGE(on,
+        "held press should latch ON exactly once, not oscillate");
+
+    uint8_t up[8] = {0};
+    updateInputState(state, prevData, up, 8);
+    on = leftSignal.update(state.test(7));
+    TEST_ASSERT_TRUE_MESSAGE(on,
+        "releasing a toggle button must not change the latched state");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_toggle_button_alternates_every_press);
+    RUN_TEST(test_momentary_button_held_across_frames);
+    RUN_TEST(test_toggle_button_flips_once_per_held_press);
     return UNITY_END();
 }

--- a/lights_v2/steering_wheel/src/main.cpp
+++ b/lights_v2/steering_wheel/src/main.cpp
@@ -9,6 +9,7 @@ MCP2515 mcp2515(10);
 constexpr uint8_t PINS [] = { 2, 3, 4, 5, 6, 7, 8, 9 };
 constexpr size_t NUMPINS = 8;
 constexpr long unsigned int debounceTime = 20;
+constexpr unsigned long sendInterval = 20;
 
 uint8_t inputState = 0;
 uint8_t lastRawState = 0;
@@ -18,6 +19,7 @@ uint8_t lastStableState = 0;
 struct can_frame msg;
 
 inline void readPinMask(const uint8_t pins [], const size_t size) {
+  inputState = 0;
   for (size_t i = 0; i < size; i++) {
     if (digitalRead(pins[i]) == LOW) {
       inputState |= (1U << i);
@@ -64,22 +66,32 @@ void loop () {
 
   updateInputs(PINS, NUMPINS);
 
-  msg.can_id = 0x100;
-  msg.can_dlc = 8;
-
   uint8_t pressed = stableState & ~lastStableState;
 
   for (size_t i = 0; i < NUMPINS; i++) {
-    msg.data[i] = 0x00;
-  }
-
-  for (size_t i = 0; i < NUMPINS; i++) {
     if (pressed & (1U << i)) {
-      msg.data[i] = i+2;
+      Serial.print("Pin active: ");
+      Serial.print(i+2);
+      Serial.println();
     }
   }
 
-  mcp2515.sendMessage(&msg);
+  // Send the held-state level (see input_decoder.h / button.h) only when the
+  // debounced state changes - for crisp, low-latency response - or on a periodic
+  // heartbeat so a dropped frame can't leave the relay with a stale view.
+  // Sending every loop instead floods the bus and overruns the relay's two RX
+  // buffers, which makes button presses register late.
+  static unsigned long lastSend = 0;
+  if (stableState != lastStableState || millis() - lastSend >= sendInterval) {
+    msg.can_id = 0x100;
+    msg.can_dlc = 8;
+    for (size_t i = 0; i < NUMPINS; i++) {
+      msg.data[i] = (stableState & (1U << i)) ? (i + 2) : 0x00;
+    }
+    mcp2515.sendMessage(&msg);
+    lastSend = millis();
+  }
+
   lastStableState = stableState;
 }
 


### PR DESCRIPTION
Steering wheel:
- Transmit the current held state (level) each frame instead of only the rising-edge frame, so momentary relays (horn, brake) stay closed while held and toggle relays can't miss a press when a single frame drops.
- Pace the bus: send on debounced state change or a 20ms heartbeat instead of flooding every loop, which was overrunning the relay's RX buffers.

Relay:
- Move the front blinkers off A6/A7 (analog-input-only on the Nano, no GPIO driver) to D2/D3 so they can actually be driven. NOTE: requires rewiring those two relay control lines.
- Hazards drive all four lamps to a shared phase off a dedicated timer instead of toggle()ing each one, so a brake tap or latched turn signal can't desync them.
- Make turn signals mutually exclusive like a turn stalk: engaging one side cancels the other, so both can no longer latch on and fight over the shared timer (which made pressing one side appear to toggle the other and left the signals impossible to turn off). A freshly engaged signal lights immediately.
- Log each signal on its rising edge only; per-loop Serial.println was stalling the loop and backing up the CAN RX buffers.

Tests:
- Add momentary-hold and toggle-held-across-frames regression tests.