### PR TITLE
Debounce and latch the e-stop input

### DIFF
--- a/battery_protection/bps_v1/include/bps_logic.h
+++ b/battery_protection/bps_v1/include/bps_logic.h
@@ -100,3 +100,45 @@ inline bool evaluateFault(const BpsData &d, bool liveFault, bool &lastFault){
     }
     return false;
 }
+
+/* ---------- E-stop debounce ----------
+   The e-stop input (D3, INPUT_PULLUP, active-HIGH when pressed) is a mechanical
+   contact and bounces for a few ms on both press and release. loop() reads the
+   pin with a bare digitalRead() every iteration, so during the bounce window the
+   reported state flips HIGH<->LOW several times. Each flip re-derives the fault
+   code (FC_ESTOP <-> FC_NONE) and fires an immediate 0x791 fault-detail frame,
+   turning one physical press into a burst of spurious CAN traffic and lamp/fan
+   chatter. Require the raw level to hold steady for ESTOP_DEBOUNCE_MS before the
+   debounced state is allowed to change. */
+constexpr unsigned long ESTOP_DEBOUNCE_MS = 20;   // contacts settle well under 20 ms
+
+struct EstopDebounce {
+    bool          stable    = false;   // debounced state reported to the caller
+    bool          candidate = false;   // raw level currently being timed
+    unsigned long since     = 0;       // millis() when `candidate` was first seen
+};
+
+/* Feed the raw pin level and the current millis() every loop. The returned
+   (debounced) state only flips once `raw` has held its new value continuously
+   for ESTOP_DEBOUNCE_MS; bounce pulses shorter than that are rejected. */
+inline bool debounceEstop(EstopDebounce &s, bool raw, unsigned long now){
+    if (raw != s.candidate) {
+        // Level changed — (re)start the settle timer on the new candidate.
+        s.candidate = raw;
+        s.since     = now;
+    } else if (raw != s.stable && (now - s.since) >= ESTOP_DEBOUNCE_MS) {
+        // Candidate has held steady long enough — accept it.
+        s.stable = raw;
+    }
+    return s.stable;
+}
+
+/* E-stop trip latch: like the two-strike fault latch and the CAN LATCHED state,
+   a confirmed (debounced) e-stop press is a safety trip that must persist until
+   the board is power-cycled — releasing the button does NOT clear it, otherwise
+   the reported fault would drop while the contactors stay open. Pass the
+   debounced level in; the latch stays set once it has ever seen a press. */
+inline bool latchEstop(bool &estopLatched, bool debouncedPressed){
+    if (debouncedPressed) estopLatched = true;
+    return estopLatched;
+}

--- a/battery_protection/bps_v1/src/main.cpp
+++ b/battery_protection/bps_v1/src/main.cpp
@@ -15,6 +15,12 @@
  *    - Forced to 100% on any fault, e-stop, or CAN watchdog event
  *    - Held at 0% until first valid CAN temp reading (temp_hi != 0xFF)
  *
+ *  E-stop behavior:
+ *    - Debounced: raw D3 level must hold steady for ESTOP_DEBOUNCE_MS before
+ *      the state changes, so contact bounce cannot chatter the fault code / lamp
+ *    - Latched: a confirmed press trips until power cycle; releasing the button
+ *      does NOT clear it (matches the two-strike and CAN-latched fault behavior)
+ *
  *  CAN watchdog (3 states):
  *    NOMINAL  -- frames arriving within 2000 ms, normal operation
  *    TIMEOUT  -- no valid frame for >2000 ms; contactors open immediately,
@@ -127,6 +133,9 @@ bool lastFault        = false;   // two-strike latch support
 bool contactorsClosed = false;
 bool prechargeClosed  = false;
 volatile bool estopEdge = false;
+
+EstopDebounce estopDebounce;   // filters mechanical contact bounce on ESTOP_PIN
+bool estopLatched = false;     // e-stop trip latch — cleared only by power cycle
 
 void eStopISR() { estopEdge = true; }
 
@@ -445,7 +454,12 @@ void loop() {
   /* ---- 3. Evaluate threshold faults via bps_logic.h ----
      evaluateFault() defers until dataReady() (all 3 frame types seen),
      then applies a two-strike latch before tripping. */
-  bool estopHigh = digitalRead(ESTOP_PIN);
+  // Debounce the raw pin so contact bounce can't chatter the fault code /
+  // 0x791 fault frames / lamp on a single physical press or release, then latch:
+  // a confirmed press trips until power cycle so releasing the button can't drop
+  // the reported fault while the contactors stay open.
+  bool estopNow  = debounceEstop(estopDebounce, digitalRead(ESTOP_PIN), millis());
+  bool estopHigh = latchEstop(estopLatched, estopNow);
   liveFault = evaluateFault(bps, liveFault, lastFault);
 
   /* ---- 4. Actuate contactors ---- */

--- a/battery_protection/bps_v1/test/test_native/test_main.cpp
+++ b/battery_protection/bps_v1/test/test_native/test_main.cpp
@@ -348,6 +348,131 @@ void test_integration_data_keeps_updating_while_latched(void){
 }
 
 /* ================================================================
+ *  E-stop debounce
+ *
+ *  Reproduces the un-debounced glitch behaviour and verifies the fix.
+ *  A physical e-stop press is modelled as a (level, timestamp) trace:
+ *  a few ms of contact bounce followed by a settled level. main.cpp
+ *  currently feeds the *raw* level straight into the fault logic, so
+ *  every bounce edge counts as a state change.
+ * ================================================================ */
+struct EstopSample { bool level; unsigned long t; };
+
+/* Count how many times the boolean value changes across a sequence. */
+static int countBoolTransitions(const bool *seq, int n){
+    int c = 0;
+    for (int i = 1; i < n; ++i) if (seq[i] != seq[i-1]) ++c;
+    return c;
+}
+
+/* A realistic press: idle LOW, ~4 ms of contact bounce, then held HIGH
+   past the 20 ms debounce window (timestamps in ms). */
+static const EstopSample kPress[] = {
+    {false, 0}, {false, 5},
+    {true, 10}, {false, 11}, {true, 12}, {false, 13}, {true, 14},  // bounce
+    {true, 20}, {true, 30}, {true, 40}, {true, 50}                 // settled HIGH
+};
+static const int kPressLen = sizeof(kPress) / sizeof(kPress[0]);
+
+/* CURRENT behaviour (the bug): main.cpp uses `digitalRead(ESTOP_PIN)`
+   verbatim, so the raw trace of a single press contains many transitions —
+   each one re-derives faultCode and fires an immediate 0x791 frame. */
+void test_estop_raw_read_glitches_on_bounce(void){
+    bool raw[kPressLen];
+    for (int i = 0; i < kPressLen; ++i) raw[i] = kPress[i].level;
+    // A single physical press glitches many times when read raw.
+    TEST_ASSERT_TRUE(countBoolTransitions(raw, kPressLen) > 1);
+}
+
+/* FIXED behaviour: debounceEstop() collapses the bounce into exactly one
+   clean transition, and still reports the press once it settles. */
+void test_estop_debounce_suppresses_bounce(void){
+    EstopDebounce s;
+    bool debounced[kPressLen];
+    for (int i = 0; i < kPressLen; ++i)
+        debounced[i] = debounceEstop(s, kPress[i].level, kPress[i].t);
+
+    TEST_ASSERT_EQUAL_INT(1, countBoolTransitions(debounced, kPressLen));
+    TEST_ASSERT_TRUE(debounced[kPressLen - 1]);   // press is reported once settled
+}
+
+/* A noise spike shorter than the debounce window never flips the state. */
+void test_estop_debounce_rejects_short_spike(void){
+    EstopDebounce s;
+    TEST_ASSERT_FALSE(debounceEstop(s, false, 0));
+    TEST_ASSERT_FALSE(debounceEstop(s, true,  1));   // spike appears
+    TEST_ASSERT_FALSE(debounceEstop(s, true,  5));   // still within 20 ms window
+    TEST_ASSERT_FALSE(debounceEstop(s, false, 6));   // spike gone before settling
+    TEST_ASSERT_FALSE(debounceEstop(s, false, 40));  // stayed released the whole time
+}
+
+/* A genuine sustained press is accepted exactly at the debounce boundary. */
+void test_estop_debounce_accepts_sustained_press(void){
+    EstopDebounce s;
+    TEST_ASSERT_FALSE(debounceEstop(s, true, 100));                  // t=0 of press
+    TEST_ASSERT_FALSE(debounceEstop(s, true, 100 + ESTOP_DEBOUNCE_MS - 1));
+    TEST_ASSERT_TRUE (debounceEstop(s, true, 100 + ESTOP_DEBOUNCE_MS));
+}
+
+/* Release also debounces: bounce on the way back to LOW is suppressed. */
+void test_estop_debounce_suppresses_release_bounce(void){
+    EstopDebounce s;
+    // Establish a settled pressed state first.
+    debounceEstop(s, true, 0);
+    TEST_ASSERT_TRUE(debounceEstop(s, true, ESTOP_DEBOUNCE_MS));
+
+    // Release with bounce, then settle LOW.
+    debounceEstop(s, false, 100);
+    TEST_ASSERT_TRUE (debounceEstop(s, true,  101));  // bounce back HIGH — still pressed
+    debounceEstop(s, false, 102);
+    TEST_ASSERT_TRUE (debounceEstop(s, false, 110));  // <20 ms since settling LOW
+    TEST_ASSERT_FALSE(debounceEstop(s, false, 122));  // now released after settling
+}
+
+/* ================================================================
+ *  E-stop trip latch
+ *
+ *  A confirmed e-stop press is a safety trip: it must stay active after
+ *  the button is released (contactors are opened on trip and never
+ *  reclosed in loop()), and only a power cycle clears it.
+ * ================================================================ */
+void test_estop_latch_holds_after_release(void){
+    bool latched = false;
+    TEST_ASSERT_FALSE(latchEstop(latched, false));   // idle
+    TEST_ASSERT_TRUE (latchEstop(latched, true));    // pressed -> trip
+    TEST_ASSERT_TRUE (latchEstop(latched, false));   // released -> STILL tripped
+    TEST_ASSERT_TRUE (latchEstop(latched, false));
+}
+
+void test_estop_latch_stays_clear_without_press(void){
+    bool latched = false;
+    TEST_ASSERT_FALSE(latchEstop(latched, false));
+    TEST_ASSERT_FALSE(latchEstop(latched, false));
+    TEST_ASSERT_FALSE(latched);
+}
+
+/* Integration: debounce + latch together, exactly as loop() chains them.
+   A bouncing press latches once (only after it settles) and stays tripped
+   through a bouncing release. */
+void test_estop_debounce_then_latch_persists(void){
+    EstopDebounce s;
+    bool latched = false;
+
+    // Bouncing press — not tripped until the level settles past the window.
+    latchEstop(latched, debounceEstop(s, false, 0));
+    latchEstop(latched, debounceEstop(s, true,  10));
+    latchEstop(latched, debounceEstop(s, false, 11));   // bounce
+    latchEstop(latched, debounceEstop(s, true,  12));
+    TEST_ASSERT_FALSE(latched);                          // still settling
+    TEST_ASSERT_TRUE(latchEstop(latched, debounceEstop(s, true, 40)));  // settled -> latch
+
+    // Release (with bounce) — the trip must stay latched.
+    latchEstop(latched, debounceEstop(s, false, 100));
+    latchEstop(latched, debounceEstop(s, false, 130));  // debounced back to released
+    TEST_ASSERT_TRUE(latchEstop(latched, debounceEstop(s, false, 200)));
+}
+
+/* ================================================================
  *  Runner
  * ================================================================ */
 int main(int argc, char **argv){
@@ -397,6 +522,18 @@ int main(int argc, char **argv){
     /* integration */
     RUN_TEST(test_integration_overtemp_latch_then_update);
     RUN_TEST(test_integration_data_keeps_updating_while_latched);
+
+    /* e-stop debounce */
+    RUN_TEST(test_estop_raw_read_glitches_on_bounce);
+    RUN_TEST(test_estop_debounce_suppresses_bounce);
+    RUN_TEST(test_estop_debounce_rejects_short_spike);
+    RUN_TEST(test_estop_debounce_accepts_sustained_press);
+    RUN_TEST(test_estop_debounce_suppresses_release_bounce);
+
+    /* e-stop trip latch */
+    RUN_TEST(test_estop_latch_holds_after_release);
+    RUN_TEST(test_estop_latch_stays_clear_without_press);
+    RUN_TEST(test_estop_debounce_then_latch_persists);
 
     return UNITY_END();
 }


### PR DESCRIPTION
The e-stop trip in loop() read D3 with a bare digitalRead() every iteration. A mechanical e-stop contact bounces for several ms on press and release, so the reported state flickered HIGH<->LOW across loop iterations — each flip re-derived the fault code (FC_ESTOP <-> FC_NONE) and fired an immediate 0x791 fault-detail frame, turning one physical press into a burst of spurious CAN traffic plus lamp/fan chatter.

Add two pure, natively-testable helpers to bps_logic.h:
  - debounceEstop(): rejects level changes until the raw pin holds steady for ESTOP_DEBOUNCE_MS (20 ms).
  - latchEstop(): a confirmed press trips until power cycle, so releasing the button can't drop the reported fault while the contactors stay open — matching the two-strike and CAN-latched fault behavior.

loop() now chains debounce -> latch before using the e-stop state. Adds unit tests reproducing the bounce glitch and covering debounce rejection/acceptance and latch persistence.